### PR TITLE
Clarify image search availability in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,9 @@ Get free API keys from these services:
 - Configurable search engine targeting
 - Falls back gracefully if credentials not provided
 
-#### 7. `googleImages()` (Optional)
-- Google Images search functionality
-- Thumbnail and full-size image URLs
-- Integrated with main search results
+#### 7. Image search (planned)
+- Image search support (`googleImages()`) is planned but currently not implemented.
+  It will integrate with the main search results when available.
 
 ## 📋 Usage Examples
 


### PR DESCRIPTION
## Summary
- Update docs to note that `googleImages()` image search is planned but not yet implemented.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986779bac4832bb19665222e54afc5