### PR TITLE
Handle unsuccessful API results in comprehensive search

### DIFF
--- a/deepResearch.js
+++ b/deepResearch.js
@@ -561,6 +561,9 @@ class DeepResearcher {
                     if (result && result.success) {
                         results.sources[api] = result;
                         results.totalResults += result.resultsCount || 0;
+                    } else if (result && !result.success) {
+                        results.errors.push({ api, error: result.error });
+                        Logger.warn(`${api} returned an unsuccessful result: ${result.error}`);
                     } else if (error) {
                         results.errors.push({ api, error });
                     }


### PR DESCRIPTION
## Summary
- Capture API calls that return unsuccessful results during comprehensive search
- Log warnings and record error details without increasing result counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898677ad914832bbe0d92dfeca6d6d5