### PR TITLE
Clarify long query truncation warning

### DIFF
--- a/deep_research_script.js
+++ b/deep_research_script.js
@@ -72,7 +72,7 @@ async function main() {
   }
 
   if (query.length > 200) {
-    console.log("⚠️ Query very long, truncating to 200 characters");
+    console.log("⚠️ Query too long, truncating to 200 characters");
     let truncated = query.substring(0, 200);
     const lastSpace = truncated.lastIndexOf(' ');
     if (lastSpace > 150) {


### PR DESCRIPTION
## Summary
- Improve grammar of the long query console warning in `deep_research_script.js`.

## Testing
- `npm test`
- `npm run test-ios`


------
https://chatgpt.com/codex/tasks/task_e_6898677e03b8832bb1801d179f647bba