### PR TITLE
Use X-Api-Key header for NewsAPI

### DIFF
--- a/deepResearch.js
+++ b/deepResearch.js
@@ -294,7 +294,7 @@ class DeepResearcher {
                 url: this.config.newsAPI.baseUrl,
                 params: params,
                 headers: {
-                    'Authorization': `Bearer ${this.config.newsAPI.apiKey}`,
+                    'X-Api-Key': this.config.newsAPI.apiKey,
                     'User-Agent': 'DeepResearchMultiApis/1.0'
                 },
                 timeout: this.config.newsAPI.timeout

--- a/iosResearch.js
+++ b/iosResearch.js
@@ -275,7 +275,7 @@ class IOSDeepResearcher {
                 url: this.config.newsAPI.baseUrl,
                 params: params,
                 headers: {
-                    'Authorization': `Bearer ${this.config.newsAPI.apiKey}`,
+                    'X-Api-Key': this.config.newsAPI.apiKey,
                     'User-Agent': 'iOS-DeepResearch/1.0'
                 },
                 timeout: this.config.newsAPI.timeout


### PR DESCRIPTION
## Summary
- Use `X-Api-Key` header in place of Bearer Authorization for NewsAPI requests
- Keep existing query parameters and user-agent headers intact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68986ace24c0832bbafab515a7097904