### PR TITLE
Skip main execution when configuration is invalid

### DIFF
--- a/deep_research_script.js
+++ b/deep_research_script.js
@@ -46,11 +46,13 @@ function validateConfiguration() {
   return true;
 }
 
+let configIsValid = true;
 try {
   validateConfiguration();
 } catch (error) {
   console.log(`❌ Configuration validation failed: ${error.message}`);
   Script.complete();
+  configIsValid = false;
 }
 
 async function main() {
@@ -266,4 +268,6 @@ function displayResults(results) {
   console.log("\n" + "=".repeat(60));
 }
 
-await main();
+if (configIsValid) {
+  await main();
+}

--- a/deep_research_script.js
+++ b/deep_research_script.js
@@ -51,8 +51,8 @@ try {
   validateConfiguration();
 } catch (error) {
   console.log(`❌ Configuration validation failed: ${error.message}`);
-  Script.complete();
   configIsValid = false;
+  Script.complete();
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- Prevent `deep_research_script.js` from running its main logic when configuration validation fails by tracking validation status and conditionally invoking `main`.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68986acf2bf8832b96a514a83ab4f0de