### PR TITLE
Load API keys from secure sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Download "Scriptable" from the App Store (free)
 1. Open Scriptable
 2. Create new script called "Deep Research"
 3. Copy the content of `deep_research_script.js`
-4. Configure your API keys
+4. Provide your API keys via Shortcuts parameters (`braveKey`/`newsKey`),
+   iOS Keychain entries (`BRAVE_API_KEY`/`NEWS_API_KEY`), or environment
+   variables. If no keys are found the script uses placeholder values and
+   warns you.
 
 ### 3. Basic Usage
 - Copy search query to clipboard → Run script → Get results from clipboard

--- a/deep_research_script.js
+++ b/deep_research_script.js
@@ -1,5 +1,12 @@
 const params = typeof args !== 'undefined' ? args.shortcutParameter : undefined;
 
+/**
+ * Retrieves a value from the Keychain by key.
+ * Returns undefined if the Keychain is not available or if an error occurs.
+ *
+ * @param {string} key - The key to retrieve from the Keychain.
+ * @returns {string|undefined} The value associated with the key, or undefined if not found or on error.
+ */
 function getKeychainValue(key) {
   if (typeof Keychain === 'undefined') return undefined;
   try {

--- a/deep_research_script.js
+++ b/deep_research_script.js
@@ -47,6 +47,15 @@ if (params) {
   if (params.maxContentLength) CONFIG.MAX_CONTENT_LENGTH = params.maxContentLength;
 }
 
+/**
+ * Determines whether a key is considered "missing" in this context.
+ * A key is considered missing if it is falsy (e.g., undefined, null, empty string, 0, false)
+ * or if it matches the provided placeholder value.
+ *
+ * @param {*} key - The value to check for presence.
+ * @param {*} placeholder - The placeholder value that indicates a missing key.
+ * @returns {boolean} True if the key is missing; otherwise, false.
+ */
 function isMissing(key, placeholder) {
   return !key || key === placeholder;
 }

--- a/iOS-SETUP.md
+++ b/iOS-SETUP.md
@@ -26,23 +26,16 @@ This comprehensive guide will help you set up the unified Deep Research script o
 
 ### 3. Configure API Keys
 
-You have three flexible options to configure your API keys:
+The script automatically looks for API keys in this order:
 
-#### Option A: Direct Configuration (Simplest)
-Edit the script and add your API keys directly in the CONFIG section:
+1. Shortcut parameters (`braveKey`, `newsKey`)
+2. iOS Keychain entries (`BRAVE_API_KEY`, `NEWS_API_KEY`)
+3. Environment variables (`BRAVE_API_KEY`, `NEWS_API_KEY`)
+4. Placeholder values in the script
 
-```javascript
-const CONFIG = {
-  BRAVE_API_KEY: "your_brave_api_key_here",
-  NEWS_API_KEY: "your_newsapi_key_here",  
-  NEWSDATA_API_KEY: "your_newsdata_key_here",
-  GOOGLE_API_KEY: "your_google_api_key_here", // Optional
-  GOOGLE_CX: "your_google_cx_here", // Optional
-  // ... rest of config
-};
-```
+If none are found, placeholders are used and the script warns you.
 
-#### Option B: iOS Keychain (Most Secure)
+#### Option A: iOS Keychain (Most Secure)
 Use iOS Shortcuts to store API keys securely:
 
 1. Open iOS Shortcuts app
@@ -52,8 +45,12 @@ Use iOS Shortcuts to store API keys securely:
    - Key: "BRAVE_API_KEY", Value: your key
    - Repeat for other API keys (NEWS_API_KEY, NEWSDATA_API_KEY, etc.)
 
-#### Option C: Via iOS Shortcuts Parameters
+#### Option B: Via iOS Shortcuts Parameters
 Pass API keys as parameters when calling from iOS Shortcuts (most flexible).
+
+#### Option C: Environment Variables
+Set `BRAVE_API_KEY` and `NEWS_API_KEY` in your environment when running
+the script outside of Shortcuts (e.g., in Node.js).
 
 ## Getting API Keys
 


### PR DESCRIPTION
## Summary
- Remove hardcoded Brave and NewsAPI keys from Scriptable script
- Read API keys from Shortcuts parameters, Keychain, or environment variables with placeholder fallback
- Document how to supply API keys via parameters, Keychain, or env vars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986ad1c7ac832b81277d33bfe77082