### PR TITLE
Load API keys from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ Get free API keys from these services:
 
 ### API Key Storage Methods
 
-#### Option A: Direct Configuration (Simplest)
+#### Option A: Environment Variables or Config File
 ```javascript
 const CONFIG = {
-  BRAVE_API_KEY: "your_brave_api_key_here",
-  NEWS_API_KEY: "your_newsapi_key_here",  
-  NEWSDATA_API_KEY: "your_newsdata_key_here",
+  BRAVE_API_KEY: process.env.BRAVE_API_KEY || '',
+  NEWS_API_KEY: process.env.NEWS_API_KEY || '',
+  NEWSDATA_API_KEY: process.env.NEWSDATA_API_KEY || '',
   // ... other settings
 };
 ```

--- a/deep_research_script.js
+++ b/deep_research_script.js
@@ -1,5 +1,15 @@
-const BRAVE_API_KEY = "BSAUZcHnbsKgi9GTsu4wQV2SPEeZ3wy";
-const NEWS_API_KEY = "09494b1a857d48a3b7fe62515c1ab8f9";
+function getApiKey(keyName) {
+  if (typeof Keychain !== 'undefined' && Keychain.contains(keyName)) {
+    return Keychain.get(keyName);
+  }
+  if (typeof process !== 'undefined' && process.env[keyName]) {
+    return process.env[keyName];
+  }
+  return '';
+}
+
+const BRAVE_API_KEY = getApiKey('BRAVE_API_KEY');
+const NEWS_API_KEY = getApiKey('NEWS_API_KEY');
 
 const CONFIG = {
   BRAVE_API_KEY: BRAVE_API_KEY,

--- a/iOS-SETUP.md
+++ b/iOS-SETUP.md
@@ -28,16 +28,16 @@ This comprehensive guide will help you set up the unified Deep Research script o
 
 You have three flexible options to configure your API keys:
 
-#### Option A: Direct Configuration (Simplest)
-Edit the script and add your API keys directly in the CONFIG section:
+#### Option A: Environment Variables or Config File
+Set API keys in your environment or config file and reference them in the script:
 
 ```javascript
 const CONFIG = {
-  BRAVE_API_KEY: "your_brave_api_key_here",
-  NEWS_API_KEY: "your_newsapi_key_here",  
-  NEWSDATA_API_KEY: "your_newsdata_key_here",
-  GOOGLE_API_KEY: "your_google_api_key_here", // Optional
-  GOOGLE_CX: "your_google_cx_here", // Optional
+  BRAVE_API_KEY: process.env.BRAVE_API_KEY || '',
+  NEWS_API_KEY: process.env.NEWS_API_KEY || '',
+  NEWSDATA_API_KEY: process.env.NEWSDATA_API_KEY || '',
+  GOOGLE_API_KEY: process.env.GOOGLE_API_KEY || '', // Optional
+  GOOGLE_CX: process.env.GOOGLE_CX || '',           // Optional
   // ... rest of config
 };
 ```

--- a/ios-config-template.js
+++ b/ios-config-template.js
@@ -1,19 +1,27 @@
 // iOS Scriptable Configuration Template for Deep Research
 // Copy this configuration into your deep_research_script.js file
 
+function getApiKey(keyName) {
+  if (typeof Keychain !== 'undefined' && Keychain.contains(keyName)) {
+    return Keychain.get(keyName);
+  }
+  if (typeof process !== 'undefined' && process.env[keyName]) {
+    return process.env[keyName];
+  }
+  return '';
+}
+
 const CONFIG = {
   // === API Keys (Required) ===
-  // Get your Brave Search API key from: https://api.search.brave.com/app/keys
-  BRAVE_API_KEY: "your_brave_api_key_here",
-  
-  // Get your NewsAPI key from: https://newsapi.org/account  
-  NEWS_API_KEY: "your_newsapi_key_here",
-  
+  // Store your keys in the iOS Keychain or set environment variables
+  BRAVE_API_KEY: getApiKey('BRAVE_API_KEY'),
+  NEWS_API_KEY: getApiKey('NEWS_API_KEY'),
+
   // === Performance Settings ===
   TIMEOUT_MS: 15000,        // Network timeout (15 seconds recommended for iOS)
   RETRY_COUNT: 2,           // Number of retry attempts for failed API calls
   MAX_RESULTS: 5,           // Maximum results per API (1-10 recommended)
-  
+
   // === Behavior Settings ===
   COPY_TO_CLIPBOARD: true,  // Automatically copy results to clipboard
   SHOW_NOTIFICATIONS: true  // Show iOS notifications for status updates


### PR DESCRIPTION
## Summary
- Load Brave and News API keys from iOS Keychain or environment variables in `deep_research_script.js`
- Document environment variable configuration for API keys
- Update iOS config template to read keys from secure storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986ad950b0832ba4175bcfc806d0f0