### PR TITLE
Guard main execution on config validation

### DIFF
--- a/deep_research_script.js
+++ b/deep_research_script.js
@@ -46,11 +46,17 @@ function validateConfiguration() {
   return true;
 }
 
-try {
-  validateConfiguration();
-} catch (error) {
-  console.log(`❌ Configuration validation failed: ${error.message}`);
-  Script.complete();
+// Validate configuration and run the main logic only if validation succeeds.
+async function runWithValidation() {
+  try {
+    validateConfiguration();
+  } catch (error) {
+    console.log(`❌ Configuration validation failed: ${error.message}`);
+    Script.complete();
+    return; // Stop execution after logging the validation failure
+  }
+
+  await main();
 }
 
 async function main() {
@@ -266,4 +272,4 @@ function displayResults(results) {
   console.log("\n" + "=".repeat(60));
 }
 
-await main();
+await runWithValidation();


### PR DESCRIPTION
## Summary
- halt execution when configuration validation fails
- run `main` only after successful validation via `runWithValidation`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986ade89b4832ba28217d733fe2901