### PR TITLE
Expand iOS detection for shell-based environments

### DIFF
--- a/iosResearch.js
+++ b/iosResearch.js
@@ -20,16 +20,16 @@ class IOSDetector {
         const userAgent = process.env.USER_AGENT || '';
         const shell = process.env.SHELL || '';
         const term = process.env.TERM || '';
-        
+        const termProgram = process.env.TERM_PROGRAM || '';
+        const shellName = path.basename(shell);
+
         return (
-            platform === 'darwin' && (
-                userAgent.includes('iOS') ||
-                shell.includes('ash') ||  // a-Shell
-                shell.includes('ish') ||  // iSH
-                term.includes('xterm-256color') ||
-                process.env.TERM_PROGRAM === 'a-Shell' ||
-                process.env.TERM_PROGRAM === 'iSH'
-            )
+            platform === 'darwin' ||
+            userAgent.includes('iOS') ||
+            termProgram === 'a-Shell' ||
+            termProgram === 'iSH' ||
+            shellName === 'ash' || // BusyBox ash used by a-Shell and iSH
+            (term.includes('xterm-256color') && (termProgram === 'a-Shell' || termProgram === 'iSH'))
         );
     }
 

--- a/test-ios.js
+++ b/test-ios.js
@@ -46,6 +46,48 @@ class IOSTestRunner {
             // This test always passes as it's just checking detection
         });
 
+        // Simulated detection for a-Shell environment
+        await this.runTest('a-Shell Detection', () => {
+            const originalShell = process.env.SHELL;
+            const originalTerm = process.env.TERM;
+            const originalProgram = process.env.TERM_PROGRAM;
+
+            process.env.SHELL = '/bin/ash';
+            process.env.TERM = 'xterm-256color';
+            process.env.TERM_PROGRAM = 'a-Shell';
+
+            const detected = IOSDetector.isIOS();
+
+            process.env.SHELL = originalShell;
+            process.env.TERM = originalTerm;
+            process.env.TERM_PROGRAM = originalProgram;
+
+            if (!detected) {
+                throw new Error('Failed to detect a-Shell environment');
+            }
+        });
+
+        // Simulated detection for iSH environment
+        await this.runTest('iSH Detection', () => {
+            const originalShell = process.env.SHELL;
+            const originalTerm = process.env.TERM;
+            const originalProgram = process.env.TERM_PROGRAM;
+
+            process.env.SHELL = '/bin/ash';
+            process.env.TERM = 'xterm-256color';
+            process.env.TERM_PROGRAM = 'iSH';
+
+            const detected = IOSDetector.isIOS();
+
+            process.env.SHELL = originalShell;
+            process.env.TERM = originalTerm;
+            process.env.TERM_PROGRAM = originalProgram;
+
+            if (!detected) {
+                throw new Error('Failed to detect iSH environment');
+            }
+        });
+
         // Test iOS Path Resolution
         await this.runTest('iOS Path Resolution', () => {
             const configPath = IOSDetector.getIOSCompatiblePath('config.json');


### PR DESCRIPTION
## Summary
- Broaden `IOSDetector.isIOS` to recognize a-Shell and iSH via shell and terminal indicators even when `process.platform` isn't `darwin`.
- Add simulated a-Shell and iSH detection tests to `test-ios.js`.

## Testing
- `npm test`
- `npm run test-ios`


------
https://chatgpt.com/codex/tasks/task_e_68986ae3cb94832ba0f603836d7c1a51