### PR TITLE
Handle Newsdata array fields consistently

### DIFF
--- a/deepResearch.js
+++ b/deepResearch.js
@@ -496,17 +496,26 @@ class DeepResearcher {
         try {
             if (data.results) {
                 data.results.forEach(article => {
+                    const creator = Array.isArray(article.creator)
+                        ? article.creator.join(', ')
+                        : (article.creator || 'Unknown creator');
+                    const category = Array.isArray(article.category)
+                        ? article.category.join(', ')
+                        : article.category || null;
+                    const country = Array.isArray(article.country)
+                        ? article.country.join(', ')
+                        : article.country || null;
                     results.push({
                         title: article.title || 'No title',
                         url: article.link || '',
                         description: article.description || 'No description',
                         content: article.content || '',
-                        creator: article.creator || 'Unknown creator',
+                        creator: creator,
                         source: article.source_id || 'Unknown source',
                         publishedAt: article.pubDate || null,
                         imageUrl: article.image_url || null,
-                        category: article.category || null,
-                        country: article.country || null,
+                        category: category,
+                        country: country,
                         language: article.language || null
                     });
                 });

--- a/iosResearch.js
+++ b/iosResearch.js
@@ -427,11 +427,14 @@ class IOSDeepResearcher {
         try {
             if (data.results) {
                 data.results.forEach(article => {
+                    const creator = Array.isArray(article.creator)
+                        ? article.creator.join(', ')
+                        : (article.creator || 'Unknown creator');
                     results.push({
                         title: article.title || 'No title',
                         url: article.link || '',
                         description: article.description || 'No description',
-                        creator: article.creator || 'Unknown creator',
+                        creator: creator,
                         source: article.source_id || 'Unknown source',
                         publishedAt: article.pubDate || null
                     });

--- a/test.js
+++ b/test.js
@@ -185,7 +185,38 @@ async function runTests() {
         }
     });
 
-    // Test 8: Comprehensive search
+    // Test 8: Newsdata response normalization
+    await runner.test('Newsdata Response Normalization', async () => {
+        const mockData = {
+            results: [
+                {
+                    title: 'Example',
+                    link: 'https://example.com',
+                    description: 'desc',
+                    content: 'content',
+                    creator: ['A', 'B'],
+                    source_id: 'source',
+                    pubDate: '2024-01-01',
+                    image_url: 'img',
+                    category: ['tech', 'ai'],
+                    country: ['us', 'gb'],
+                    language: 'en'
+                }
+            ]
+        };
+        const normalized = researcher.processNewsdataResponse(mockData);
+        if (normalized[0].creator !== 'A, B') {
+            throw new Error('Creator array not normalized');
+        }
+        if (normalized[0].category !== 'tech, ai') {
+            throw new Error('Category array not normalized');
+        }
+        if (normalized[0].country !== 'us, gb') {
+            throw new Error('Country array not normalized');
+        }
+    });
+
+    // Test 9: Comprehensive search
     await runner.test('Comprehensive Search', async () => {
         const result = await researcher.comprehensiveSearch('test query');
         if (!result.hasOwnProperty('query')) {
@@ -202,7 +233,7 @@ async function runTests() {
         }
     });
 
-    // Test 9: Results summary generation
+    // Test 10: Results summary generation
     await runner.test('Results Summary Generation', async () => {
         const mockResults = {
             query: 'test',


### PR DESCRIPTION
## Summary
- Normalize Newsdata.io responses so creator, category, and country array fields are joined into comma-separated strings
- Apply the same normalization in the iOS research script
- Add unit test to ensure Newsdata array fields are processed correctly

## Testing
- `npm test`
- `npm run test-ios`


------
https://chatgpt.com/codex/tasks/task_e_689883433b88832b9927ab56708f9b53