### PR TITLE
feat: make summary link limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Pass API keys as parameters when calling from iOS Shortcuts
 ```javascript
 const CONFIG = {
   MAX_RESULTS: 5,              // Results per API (default: 5)
+  SUMMARY_RESULTS_LIMIT: 10,   // Links per source included in summary
   TIMEOUT_MS: 15000,           // Network timeout (default: 15s)
   RETRY_COUNT: 2,              // Retry attempts (default: 2)
   SCRAPE_CONTENT: true,        // Enable full article scraping

--- a/deepResearch.js
+++ b/deepResearch.js
@@ -137,8 +137,9 @@ class RetryUtility {
 
 // Main Research Class
 class DeepResearcher {
-    constructor() {
+    constructor(options = {}) {
         this.config = ConfigManager.loadConfig();
+        this.summaryResultsLimit = options.summaryResultsLimit || parseInt(process.env.SUMMARY_RESULTS_LIMIT, 10) || 10;
         Logger.info('DeepResearcher initialized');
     }
 
@@ -652,7 +653,7 @@ class DeepResearcher {
         Object.entries(results.sources).forEach(([api, data]) => {
             summary += `=== ${api.toUpperCase()} (${data.resultsCount} results) ===\n`;
             
-            data.results.slice(0, 5).forEach((item, index) => {
+            data.results.slice(0, this.summaryResultsLimit).forEach((item, index) => {
                 summary += `${index + 1}. ${item.title}\n`;
                 summary += `   ${item.url}\n`;
                 summary += `   ${item.description}\n\n`;

--- a/test.js
+++ b/test.js
@@ -251,13 +251,40 @@ async function runTests() {
             },
             errors: []
         };
-        
+
         const summary = researcher.generateResultsSummary(mockResults);
         if (!summary || typeof summary !== 'string') {
             throw new Error('Summary should be a non-empty string');
         }
         if (!summary.includes('Test Title')) {
             throw new Error('Summary should include result titles');
+        }
+    });
+
+    await runner.test('Summary Results Limit', async () => {
+        const limitedResearcher = new DeepResearcher({ summaryResultsLimit: 3 });
+        const mockResults = {
+            query: 'limit test',
+            timestamp: new Date().toISOString(),
+            totalResults: 5,
+            sources: {
+                testapi: {
+                    resultsCount: 5,
+                    results: [
+                        { title: 'Title1', url: 'https://1.com', description: 'd1' },
+                        { title: 'Title2', url: 'https://2.com', description: 'd2' },
+                        { title: 'Title3', url: 'https://3.com', description: 'd3' },
+                        { title: 'Title4', url: 'https://4.com', description: 'd4' },
+                        { title: 'Title5', url: 'https://5.com', description: 'd5' }
+                    ]
+                }
+            },
+            errors: []
+        };
+
+        const summary = limitedResearcher.generateResultsSummary(mockResults);
+        if (!summary.includes('Title3') || summary.includes('Title4')) {
+            throw new Error('Summary results limit not applied correctly');
         }
     });
 


### PR DESCRIPTION
## Summary
- allow DeepResearcher to configure how many links per source are included when generating summaries
- document new `SUMMARY_RESULTS_LIMIT` option in README
- test configurable summary limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b07962c988832babf806f55f2808c4